### PR TITLE
Fixes for AioStomp CONNECT message.

### DIFF
--- a/aiostomp/errors.py
+++ b/aiostomp/errors.py
@@ -20,3 +20,7 @@ class ExceededRetryCount(StompError):
 class ReceiptTimeout(StompError):
     def __init__(self, message_id: str):
         super().__init__(f"Receipt timeout for message: {message_id}")
+
+
+class ConnectionTimeout(StompError):
+    pass

--- a/aiostomp/heartbeat.py
+++ b/aiostomp/heartbeat.py
@@ -30,7 +30,7 @@ class StompHeartbeater:
             await self.stop()
 
         self.is_started = True
-        self.task = asyncio.ensure_future(self.run(), loop=self.loop)
+        self.task = asyncio.ensure_future(self.run())
 
     async def stop(self) -> None:
         if self.is_started and self.task:
@@ -48,7 +48,7 @@ class StompHeartbeater:
     async def run(self) -> None:
         while True:
             await self.send()
-            await asyncio.sleep(self.interval_cx, loop=self.loop)
+            await asyncio.sleep(self.interval_cx)
 
     @property
     def connected(self) -> bool:


### PR DESCRIPTION
* heartbeat should be connected before sending frames.
* aiostomp connect message should be awaited.
* ReceiptTimeout should pass the message ID.